### PR TITLE
Draft: Add box-surface example based on dune-assembler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.vtu
+*.pvd
+build*/
+output/
+_piecefiles/

--- a/cmake/modules/HigherOrderBgnMacros.cmake
+++ b/cmake/modules/HigherOrderBgnMacros.cmake
@@ -1,1 +1,8 @@
 # File for module specific CMake tests.
+include(FetchContent)
+
+FetchContent_Declare(fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG master
+)
+FetchContent_MakeAvailable(fmt)

--- a/dune.module
+++ b/dune.module
@@ -7,6 +7,6 @@ Module: higher-order-bgn
 Version: 0.1
 Maintainer: gh-zhang19@mails.tsinghua.edu.cn
 # Required build dependencies
-Depends: dune-curvedgrid dune-meshdist dune-gmsh4 dune-vtk dune-alugrid dune-foamgrid
+Depends: dune-curvedgrid dune-meshdist dune-gmsh4 dune-vtk dune-alugrid dune-foamgrid dune-uggrid dune-functions dune-assembler
 # Optional build dependencies
 #Suggests:

--- a/initial.ini
+++ b/initial.ini
@@ -1,7 +1,7 @@
 [grid]
 output_filename = sd
-refinement_levels = 6
-kg = 1
+refinement_levels = 4
+kg = 2
 ko = 10
 
 [grid.initial]
@@ -25,11 +25,22 @@ quad_order = 10
 [solver]
 verbose = 0
 
+[hausdorff]
+quad_order = 4
+
+[hausdorff.closest_point]
+abs_tol = 1.e-4
+max_it = 100
+
+[hausdorff.entity_search]
+num_elements = 16
+
+
 [adapt]
 start_time = 0
-end_time = 0.05
+end_time = 0.6
 timestep =  0.0125# for evolution test
-tau_ini = 0.05 # for eoc test, 0.05, 0.0125, 0.003125, 0.00078125 
+tau_ini = 0.01 # for eoc test, 0.05, 0.0125, 0.003125, 0.00078125
 # 0.05, 0.0125, 0.003125, 0.00078125, 0.0001953125
 # 0.05, 0.00625, 0.00078125, 0.00009765625, 0.00001220703125
 # 0.05, 0.003125, 0.0001953125 , 0.00001220703125 , 0.000000762939453125

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,3 +28,11 @@ target_compile_definitions("higher-order-bgn_curve" PRIVATE DUNE_GRID_PATH=\"${C
  dune_target_enable_all_packages(eoc_curve_test_ref)
  dune_default_include_directories(eoc_curve_test_ref PRIVATE)
  target_compile_definitions("eoc_curve_test_ref" PRIVATE DUNE_GRID_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/grids/\")
+
+ find_package(fmt REQUIRED)
+
+ add_executable(boxsurface boxsurface.cc)
+ target_link_dune_default_libraries(boxsurface)
+ dune_target_enable_all_packages(boxsurface)
+ dune_default_include_directories(boxsurface PRIVATE)
+ target_link_libraries(boxsurface PRIVATE fmt::fmt)

--- a/src/area.hh
+++ b/src/area.hh
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <dune/curvedgeometry/localfunctiongeometry.hh>
+#include <dune/geometry/quadraturerules.hh>
+
+namespace Dune::BGN {
+
+template <class GridView, class GridFct>
+double surface(GridView const& gridView, GridFct const& X, int quadOrder = 10)
+{
+  auto X_e = localFunction(X);
+
+  double vol = 0;
+  for (auto const& e : elements(gridView)) {
+    X_e.bind(e);
+    auto geometry = Dune::LocalFunctionGeometry{referenceElement(e), X_e};
+    const auto& quad = Dune::QuadratureRules<double, GridView::dimension>::rule(e.type(), quadOrder);
+    vol += geometry.volume(quad);
+  }
+  return vol;
+}
+
+} // end namespace Dune::BGN

--- a/src/boundarygridfactory.hh
+++ b/src/boundarygridfactory.hh
@@ -1,0 +1,103 @@
+#ifndef DUNE_BOUNDARY_GRIDFACTORY_HH
+#define DUNE_BOUNDARY_GRIDFACTORY_HH
+
+#include <cmath>
+#include <limits>
+#include <map>
+#include <vector>
+
+#include <dune/grid/common/gridfactory.hh>
+#include <dune/geometry/type.hh>
+#include <dune/geometry/utility/typefromvertexcount.hh>
+
+namespace Dune
+{
+  template <class GridType>
+  class BoundaryGridFactory
+  {
+    using ctype = typename GridType::ctype;
+
+    enum { dim = GridType::dimension };
+    enum { dimworld = GridType::dimensionworld };
+
+    struct CoordLess
+    {
+      template <class T, int N>
+      bool operator() (FieldVector<T,N> const& lhs, FieldVector<T,N> const& rhs) const
+      {
+        for (int i = 0; i < N; ++i) {
+          using std::abs;
+          if (abs(lhs[i] - rhs[i]) < std::numeric_limits<T>::epsilon())
+            continue;
+          return lhs[i] < rhs[i];
+        }
+        return false;
+      }
+    };
+
+  public:
+    /// Create a grid from the boundary intersections of a hostgrid that are accepted by the indicator
+    template <class HostGridView, class Indicator>
+    static void createBoundaryGrid (GridFactory<GridType>& factory,
+                                    HostGridView const& hostGridView,
+                                    Indicator indicator)
+    {
+      unsigned int idx = 0;
+      std::map<FieldVector<ctype, dimworld>, unsigned int, CoordLess> vertices;
+
+      for (auto const& e : elements(hostGridView)) {
+        if (not e.hasBoundaryIntersections())
+          continue;
+
+        for (auto const& is : intersections(hostGridView, e)) {
+          if (not is.boundary())
+            continue;
+
+          if (indicator(is)) {
+            auto geo = is.geometry();
+            std::vector<unsigned int> indices(geo.corners());
+            for (int i = 0; i < geo.corners(); ++i) {
+              auto it = vertices.emplace(geo.corner(i), idx);
+              if (it.second) {
+                ++idx;
+                factory.insertVertex(geo.corner(i));
+              }
+              indices[i] = it.first->second;
+            }
+            factory.insertElement(geometryTypeFromVertexCount(dim, indices.size()), indices);
+          }
+        }
+      }
+    }
+
+    /// Create a grid from all boundary intersections of a hostgrid
+    template <class HostGridView>
+    static void createBoundaryGrid (GridFactory<GridType>& factory,
+                                    HostGridView const& hostGridView)
+    {
+      createBoundaryGrid(factory, hostGridView, [](auto const& is) { return true; });
+    }
+
+    /// Create a grid from the boundary intersections of a hostgrid that are accepted by the indicator
+    template <class HostGridView, class Indicator>
+    static std::unique_ptr<GridType> createBoundaryGrid (HostGridView const& hostGridView,
+                                                         Indicator indicator)
+    {
+      GridFactory<GridType> factory;
+      createBoundaryGrid(factory, hostGridView, indicator);
+      return std::unique_ptr<GridType>(factory.createGrid());
+    }
+
+    /// Create a grid from all boundary intersections of a hostgrid
+    template <class HostGridView>
+    static std::unique_ptr<GridType> createBoundaryGrid (HostGridView const& hostGridView)
+    {
+      GridFactory<GridType> factory;
+      createBoundaryGrid(factory, hostGridView, [](auto const& is) { return true; });
+      return std::unique_ptr<GridType>(factory.createGrid());
+    }
+  };
+
+} // end namespace Dune
+
+#endif // DUNE_BOUNDARY_GRIDFACTORY_HH

--- a/src/boxsurface.cc
+++ b/src/boxsurface.cc
@@ -1,0 +1,106 @@
+#include <config.h>
+
+#include <cassert>
+#include <cmath>
+#include <thread>
+
+#include <dune/common/indices.hh>
+#include <dune/common/parametertree.hh>
+#include <dune/common/parametertreeparser.hh>
+#include <dune/common/parallel/mpihelper.hh>
+#include <dune/foamgrid/foamgrid.hh>
+#include <dune/functions/functionspacebases/compositebasis.hh>
+#include <dune/functions/functionspacebases/defaultglobalbasis.hh>
+#include <dune/functions/functionspacebases/lagrangebasis.hh>
+#include <dune/functions/functionspacebases/powerbasis.hh>
+#include <dune/functions/gridfunctions/discreteglobalbasisfunction.hh>
+#include <dune/grid/uggrid.hh>
+#include <dune/grid/utility/structuresgridfactory.hh>
+#include <dune/meshdist/hausdorffdistance.hh>
+
+#include "boundarygridfactory.hh"
+#include "gridsize.hh"
+#include "mean_curvature_flow.hh"
+#include "printerrors.hh"
+#include "runner.hh"
+#include "surface_diffusion.hh"
+
+using namespace Dune;
+using namespace std;
+
+// Define the flow type as a local-assembler factory
+using Flow = Dune::BGN::SurfaceDiffusion;
+// using Float = MeanCurvatureFlow;
+
+// Create a surface grid representing the boundary of an elongated box
+template <class GridType>
+auto createBoxBoundaryGrid(double dx, double dy, double dz)
+{
+  double d = std::min({dx,dy,dz});
+  using BoxGridType = Dune::UGGrid<GridType::dimensionworld>;
+  auto boxGrid = Dune::StructuredGridFactory<BoxGridType>::createSimplexGrid({0.0,0.0,0.0}, {dx,dy,dz}, {(unsigned int)(dx/d),(unsigned int)(dy/d),(unsigned int)(dz/d)});
+  return Dune::BoundaryGridFactory<GridType>::createBoundaryGrid(boxGrid->leafGridView());
+}
+
+// Create a function-space basis [V^3 x V] suitable for the geometric flow problem
+template <int k = 2, class GridView>
+auto makeFlowBasis(GridView const& gridView)
+{
+  using namespace Dune::Functions::BasisFactory;
+  return makeBasis(gridView,
+      composite(power<GridView::dimensionworld>(lagrange<k>(), flatInterleaved()),
+                lagrange<k>(),
+                flatLexicographic()));
+}
+
+int main(int argc, char *argv[])
+{
+  Dune::MPIHelper::instance(argc, argv);
+
+  std::string inifile = "mcf.ini";
+  if (argc > 1)
+    inifile = argv[1];
+
+  std::size_t threadCount = std::thread::hardware_concurrency();
+  if (argc>2)
+    threadCount = std::stoul(std::string(argv[2]));
+  std::cout << "Using parallel executor with " << threadCount << " threads" << std::endl;
+
+  Dune::ParameterTree pt;
+  Dune::ParameterTreeParser::readINITree(inifile, pt);
+
+  auto hostGrid = createBoxBoundaryGrid<Dune::FoamGrid<2,3>>(10,1,1);
+
+  int maxLevel = pt.get<int>("grid.refinement_levels", 3);
+  hostGrid->globalRefine(maxLevel+2);
+
+  auto identityMap = [](auto const& x) { return x; };
+
+  int kg = pt.get<int>("grid.kg", 2);
+  assert(kg == 2);
+  double tau_ini = pt.get<double>("adapt.tau_ini", 0.05);
+
+  std::cout << "Compute a reference solution..." << std::endl;
+  using namespace Dune::Functions::BasisFactory;
+  auto feBasis = makeFlowBasis<2>(hostGrid->leafGridView());
+  auto solution = Dune::BGN::run<Flow>(pt, tau_ini, feBasis, identityMap, "output_ref.pvd", threadCount);
+  auto positionBasis = Dune::Functions::subspaceBasis(feBasis, Dune::Indices::_0);
+  auto X = Dune::Functions::makeDiscreteGlobalBasisFunction<Dune::FieldVector<double,3>>(positionBasis, solution);
+
+  std::vector<double> errs, hs;
+  for (int level = 0; level <= maxLevel; ++level) {
+    std::cout << "Compute solution on level " << level << " ..." << std::endl;
+    auto feBasis0 = makeFlowBasis<2>(hostGrid->levelGridView(level));
+    auto solution0 = Dune::BGN::run<Flow>(pt, tau_ini,  feBasis0, identityMap, "output_" + std::to_string(level) + ".pvd", threadCount);
+    auto positionBasis0 = Dune::Functions::subspaceBasis(feBasis0, Dune::Indices::_0);
+    auto X0 = Dune::Functions::makeDiscreteGlobalBasisFunction<Dune::FieldVector<double,3>>(positionBasis0, solution0);
+
+    auto error0 = Dune::MeshDist::meanSquareError(X,X0,pt.sub("hausdorff"));
+    std::cout << "error(" << level << ")  = " << error0  << std::endl;
+
+    errs.push_back(error0);
+    hs.push_back(gridSize(hostGrid->levelGridView(level)));
+  }
+
+  Dune::printErrorsClassic(std::cout, hs, {"dist(G,Gh)"}, {errs});
+}

--- a/src/boxsurface.cc
+++ b/src/boxsurface.cc
@@ -15,7 +15,7 @@
 #include <dune/functions/functionspacebases/powerbasis.hh>
 #include <dune/functions/gridfunctions/discreteglobalbasisfunction.hh>
 #include <dune/grid/uggrid.hh>
-#include <dune/grid/utility/structuresgridfactory.hh>
+#include <dune/grid/utility/structuredgridfactory.hh>
 #include <dune/meshdist/hausdorffdistance.hh>
 
 #include "boundarygridfactory.hh"
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
   std::cout << "Compute a reference solution..." << std::endl;
   using namespace Dune::Functions::BasisFactory;
   auto feBasis = makeFlowBasis<2>(hostGrid->leafGridView());
-  auto solution = Dune::BGN::run<Flow>(pt, tau_ini, feBasis, identityMap, "output_ref.pvd", threadCount);
+  auto solution = run<Flow>(pt, tau_ini, feBasis, identityMap, "output2_ref.pvd", threadCount);
   auto positionBasis = Dune::Functions::subspaceBasis(feBasis, Dune::Indices::_0);
   auto X = Dune::Functions::makeDiscreteGlobalBasisFunction<Dune::FieldVector<double,3>>(positionBasis, solution);
 
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
   for (int level = 0; level <= maxLevel; ++level) {
     std::cout << "Compute solution on level " << level << " ..." << std::endl;
     auto feBasis0 = makeFlowBasis<2>(hostGrid->levelGridView(level));
-    auto solution0 = Dune::BGN::run<Flow>(pt, tau_ini,  feBasis0, identityMap, "output_" + std::to_string(level) + ".pvd", threadCount);
+    auto solution0 = run<Flow>(pt, tau_ini,  feBasis0, identityMap, "output2_" + std::to_string(level) + ".pvd", threadCount);
     auto positionBasis0 = Dune::Functions::subspaceBasis(feBasis0, Dune::Indices::_0);
     auto X0 = Dune::Functions::makeDiscreteGlobalBasisFunction<Dune::FieldVector<double,3>>(positionBasis0, solution0);
 
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     std::cout << "error(" << level << ")  = " << error0  << std::endl;
 
     errs.push_back(error0);
-    hs.push_back(gridSize(hostGrid->levelGridView(level)));
+    hs.push_back(Dune::BGN::gridSize(hostGrid->levelGridView(level)));
   }
 
   Dune::printErrorsClassic(std::cout, hs, {"dist(G,Gh)"}, {errs});

--- a/src/gridsize.hh
+++ b/src/gridsize.hh
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <algorithm>
+
+namespace Dune::BGN {
+
+template <class GridView>
+double gridSize(GridView const& gridView)
+{
+  using std::max;
+  double h = 0;
+  for (auto const& e : elements(gridView, Dune::Partitions::interior)) {
+    for (unsigned int i = 0; i < e.subEntities(GridView::dimension-1); ++i)
+      h = max(h, e.template subEntity<GridView::dimension - 1>(i).geometry().volume());
+  }
+  return h;
+}
+
+} // end namespace Dune::BGN

--- a/src/localfunctiongeometrydatacollector.hh
+++ b/src/localfunctiongeometrydatacollector.hh
@@ -1,0 +1,163 @@
+#ifndef DUNE_VTK_DATACOLLECTORS_LOCALFUNCTIONGEOMETRYDATACOLLECTOR_HH
+#define DUNE_VTK_DATACOLLECTORS_LOCALFUNCTIONGEOMETRYDATACOLLECTOR_HH
+
+#include <vector>
+
+#include <dune/common/referencehelper.hh>
+#include <dune/geometry/referenceelements.hh>
+#include <dune/grid/common/mcmgmapper.hh>
+#include <dune/grid/common/partitionset.hh>
+#include <dune/vtk/types.hh>
+#include <dune/vtk/datacollectors/unstructureddatacollector.hh>
+
+namespace Dune::Vtk {
+
+/// \brief DataCollector for dune-vtk writers extracting the parametrized geometry from
+/// a local-to-global coordinate mapping and writing quadratic VTK elements
+/**
+ * To write curved elements, a \ref CurvedGeometry is constructed on-the-fly from the given
+ * mappings in the constructor.
+ *
+ * \tparam GridView  The grid-view to write
+ * \tparam Geometry  The CurvedGeometry to use for element parametrization
+ **/
+template <class GridView, class GF>
+class LocalFunctionGeometryDataCollector
+    : public UnstructuredDataCollectorInterface<GridView,
+        LocalFunctionGeometryDataCollector<GridView,GF>, Partitions::All>
+{
+  using Self = LocalFunctionGeometryDataCollector;
+  using Super = Vtk::UnstructuredDataCollectorInterface<GridView, Self, Partitions::All>;
+  using GridFunction = GF;
+
+  static auto nodeMapper (const GridView& gridView, Vtk::CellType::Parametrization param)
+  {
+    auto layout = [param](Dune::GeometryType gt, int dimgrid) -> unsigned int {
+      auto cellType = Dune::Vtk::CellType{gt,param};
+      return cellType.layout(gt.dim());
+    };
+    return Dune::MultipleCodimMultipleGeomTypeMapper(gridView, layout);
+  }
+
+  GridFunction gf_;
+  Vtk::CellType::Parametrization parametrization_;
+  Dune::MultipleCodimMultipleGeomTypeMapper<GridView> mapper_;
+
+public:
+  using Super::dim;
+  using Super::partition; // NOTE: cell-type data-collector currently implemented for the All partition only
+  using Super::gridView;
+
+public:
+  LocalFunctionGeometryDataCollector (GridView const& gridView, const GridFunction& gf, Vtk::CellType::Parametrization param = Vtk::CellType::LINEAR)
+    : Super(gridView)
+    , gf_(gf)
+    , parametrization_(param)
+    , mapper_(nodeMapper(Super::gridView(), param))
+  {}
+
+  /// Update the mapper
+  void updateImpl ()
+  {
+    mapper_.update(Super::gridView());
+  }
+
+  /// Return number of vertices + number of edge
+  std::uint64_t numPointsImpl () const
+  {
+    return mapper_.size();
+  }
+
+  /// Return a vector of point coordinates.
+  /**
+  * The vector of point coordinates is composed of vertex coordinates first and second
+  * edge center coordinates.
+  **/
+  template <class T>
+  std::vector<T> pointsImpl () const
+  {
+    std::vector<T> data(this->numPoints() * 3);
+    auto lf = localFunction(Dune::resolveRef(gf_));
+    for (auto const& c : elements(gridView(), partition)) {
+      lf.bind(c);
+      Vtk::CellType cellType(c.type(), parametrization_);
+      auto refElem = referenceElement<T,dim>(c.type());
+
+      for (int codim = dim, j = 0; codim >= 0 && j < cellType.size(); --codim) {
+        for (int i = 0; i < refElem.size(codim) && j < cellType.size(); ++i,++j) {
+          std::int64_t idx = 3 * mapper_.subIndex(c,i,codim);
+          auto v = lf(refElem.position(i,codim));
+          for (std::size_t j = 0; j < v.size(); ++j)
+            data[idx + j] = T(v[j]);
+          for (std::size_t j = v.size(); j < 3u; ++j)
+            data[idx + j] = T(0);
+        }
+      }
+    }
+    return data;
+  }
+
+  /// Return number of grid cells
+  std::uint64_t numCellsImpl () const
+  {
+    return gridView().size(0);
+  }
+
+  /// \brief Return cell types, offsets, and connectivity. \see Cells
+  /**
+  * The cell connectivity is composed of cell vertices first and second cell edges,
+  * where the indices are grouped [vertex-indices..., (#vertices)+edge-indices...]
+  **/
+  Cells cellsImpl () const
+  {
+    Cells cells;
+    cells.connectivity.reserve(this->numPoints());
+    cells.offsets.reserve(this->numCells());
+    cells.types.reserve(this->numCells());
+
+    std::int64_t old_o = 0;
+    for (auto const& c : elements(gridView(), partition)) {
+      Vtk::CellType cellType(c.type(), parametrization_);
+      auto refElem = referenceElement(c);
+
+      for (int codim = dim, j = 0; codim >= 0 && j < cellType.size(); --codim) {
+        for (int i = 0; i < refElem.size(codim) && j < cellType.size(); ++i,++j) {
+          int k = cellType.permutation(j);
+          cells.connectivity.push_back(mapper_.subIndex(c,k,codim));
+        }
+      }
+      cells.offsets.push_back(old_o += cellType.size());
+      cells.types.push_back(cellType.type());
+    }
+    return cells;
+  }
+
+  /// Evaluate the `fct` at element vertices and edge centers in the same order as the point coords.
+  template <class T, class GlobalFunction>
+  std::vector<T> pointDataImpl (GlobalFunction const& fct) const
+  {
+    std::vector<T> data(this->numPoints() * fct.numComponents());
+    auto localFct = localFunction(fct);
+    for (auto const& c : elements(gridView(), partition)) {
+      localFct.bind(c);
+      Vtk::CellType cellType{c.type(), parametrization_};
+      auto refElem = referenceElement(c);
+
+      for (int codim = dim, j = 0; codim >= 0 && j < cellType.size(); --codim) {
+        for (int i = 0; i < refElem.size(codim) && j < cellType.size(); ++i,++j) {
+          int k = cellType.permutation(j);
+          std::int64_t idx = fct.numComponents() * mapper_.subIndex(c,k,codim);
+          auto v = refElem.position(k,codim);
+          for (int comp = 0; comp < fct.numComponents(); ++comp)
+            data[idx + comp] = T(localFct.evaluate(comp, v));
+        }
+      }
+      localFct.unbind();
+    }
+    return data;
+  }
+};
+
+} // end namespace Dune::Vtk
+
+#endif // DUNE_VTK_DATACOLLECTORS_LOCALFUNCTIONGEOMETRYDATACOLLECTOR_HH

--- a/src/mean_curvature_flow.hh
+++ b/src/mean_curvature_flow.hh
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <iostream>
+#include <vector>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+#include <dune/common/rangeutilities.hh>
+#include <dune/curvedgeometry/localfunctiongeometry.hh>
+#include <dune/geometry/quadraturerules.hh>
+
+
+namespace Dune::BGN {
+
+/**
+ * \brief Local assembler for mean curvature flow.
+ */
+template <class LocalView, class GridFct>
+class MCFLocalAssembler
+{
+  using GridView = typename LocalView::GridView;
+  using Element = typename LocalView::Element;
+  using LocalFct = std::decay_t<decltype(localFunction(std::declval<Dune::ResolveRef_t<GridFct> const&>()))>;
+
+  static const int dim = Element::dimension;
+  static const int dow = GridView::dimensionworld;
+
+public:
+  template <class Basis>
+  MCFLocalAssembler (const Basis&, const GridFct& X, int quadOrder, double tau)
+    : X_(X)
+    , quadOrder_(quadOrder)
+    , tau_(tau)
+  {}
+
+  void bindLocalViews (const LocalView& testLocalView, const LocalView& trialLocalView)
+  {
+    testLocalView_ = &testLocalView;
+    trialLocalView_ = &trialLocalView;
+    X_e.emplace(localFunction(Dune::resolveRef(X_)));
+  }
+
+  void bindElement (const Element& element)
+  {
+    X_e->bind(element);
+  }
+
+  template <class LocalPattern>
+  void assembleElementMatrixPattern (const Element& e, LocalPattern& p) noexcept
+  {
+    using namespace Dune::Indices;
+    const auto& node = testLocalView_->tree();
+    const auto& localFE = node.child(_1).finiteElement();
+
+    for (auto i : Dune::range(localFE.size())) {
+      for (auto j : Dune::range(localFE.size())) {
+        auto row = node.child(_1).localIndex(i);
+        auto col = node.child(_1).localIndex(j);
+        p.add(row,col);
+
+        for (auto k : Dune::range(node.child(_0).degree())) {
+          auto row_k = node.child(_0).child(k).localIndex(i);
+          auto col_k = node.child(_0).child(k).localIndex(j);
+          p.add(row,col_k);
+          p.add(row_k,col);
+          p.add(row_k,col_k);
+        }
+      }
+    }
+  }
+
+  template <class LocalMatrix>
+  void assembleElementMatrix (const Element& e, LocalMatrix& localMatrix)
+  {
+    auto geometry = Dune::LocalFunctionGeometry{referenceElement(e), *X_e};
+
+    using namespace Dune::Indices;
+
+    const auto& node = testLocalView_->tree();
+    const auto& localFE = node.child(_1).finiteElement();
+    assert(node.child(_0).degree() == dow);
+
+    values_.resize(localFE.size());
+    jacobians_.resize(localFE.size());
+    refJacobians_.resize(localFE.size());
+
+    const auto& quad = Dune::QuadratureRules<double, dim>::rule(e.type(), quadOrder_);
+    for (const auto& [x,w] : quad)
+    {
+      const auto dx = geometry.integrationElement(x) * w;
+      const auto Jit = geometry.jacobianInverse(x);
+      const auto n = geometry.normal(x);
+
+      localFE.localBasis().evaluateFunction(x, values_);
+      localFE.localBasis().evaluateJacobian(x, refJacobians_);
+      for (auto i : Dune::range(localFE.size()))
+        jacobians_[i] = refJacobians_[i] * Jit;
+
+      for (auto i : Dune::range(localFE.size())) {
+        for (auto j : Dune::range(localFE.size())) {
+          auto row = node.child(_1).localIndex(i);
+          auto col = node.child(_1).localIndex(j);
+
+          // tau * (grad(v), grad(w))
+          const auto laplace = jacobians_[i][0].dot(jacobians_[j][0]);
+          localMatrix[row][col] -= tau_ * values_[i] * values_[j] * dx;
+
+          for (auto k : Dune::range(node.child(_0).degree())) {
+            auto row_k = node.child(_0).child(k).localIndex(i);
+            auto col_k = node.child(_0).child(k).localIndex(j);
+
+            // (v, normal*w)
+            const auto mass_normal = values_[i] * values_[j] * n[k];
+            localMatrix[row][col_k] += mass_normal * dx;
+            localMatrix[row_k][col] += mass_normal * dx;
+
+            // (grad(v), grad(w))
+            localMatrix[row_k][col_k] += laplace * dx;
+          }
+        }
+      }
+    }
+  }
+
+  void bindLocalView (const LocalView& testLocalView)
+  {
+    testLocalView_ = &testLocalView;
+    X_e.emplace(localFunction(Dune::resolveRef(X_)));
+  }
+
+  template <class LocalVector>
+  void assembleElementVector (const Element& e, LocalVector& localVector)
+  {
+    using namespace Dune::Indices;
+    auto geometry = Dune::LocalFunctionGeometry{referenceElement(e), *X_e};
+
+    const auto& node = testLocalView_->tree();
+    const auto& localFE = node.child(_1).finiteElement();
+    values_.resize(localFE.size());
+
+    const auto& quad = Dune::QuadratureRules<double, dim>::rule(e.type(), quadOrder_);
+    for (const auto& [x,w] : quad)
+    {
+      const auto dx = geometry.integrationElement(x) * w;
+      const auto n = geometry.normal(x);
+
+      localFE.localBasis().evaluateFunction(x, values_);
+
+      auto X_n = (*X_e)(x).dot(n);
+      for (auto i : Dune::range(localFE.size())) {
+        auto row = node.child(_1).localIndex(i);
+        localVector[row] += values_[i] * X_n * dx;
+      }
+    }
+  }
+
+private:
+  GridFct X_;
+  std::optional<LocalFct> X_e;
+  int quadOrder_;
+  double tau_;
+
+  const LocalView* testLocalView_ = nullptr;
+  const LocalView* trialLocalView_ = nullptr;
+  std::vector<Dune::FieldMatrix<double,1,dim>> refJacobians_;
+  std::vector<Dune::FieldMatrix<double,1,dow>> jacobians_;
+  std::vector<Dune::FieldVector<double,1>> values_;
+};
+
+template <class Basis, class GridFct>
+MCFLocalAssembler(const Basis&, const GridFct& Xh, int, double)
+  -> MCFLocalAssembler<typename Basis::LocalView, GridFct>;
+
+/**
+ * \brief Factory for the mean curvature flow local assembler.
+ * \relates MCFLocalAssembler
+ */
+struct MeanCurvatureFlow
+{
+  template <class Basis, class GridFct>
+  auto operator() (const Basis& basis, const GridFct& X, int quadOrder, double tau) const
+  {
+    return MCFLocalAssembler{basis,X,quadOrder,tau};
+  }
+};
+
+} // end namespace Dune::BGN

--- a/src/printerrors.hh
+++ b/src/printerrors.hh
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <tuple>
+#include <cmath>
+#include <iostream>
+
+#include <fmt/format.h>
+
+#if USE_FLOAT128
+
+template <>
+struct fmt::formatter<Dune::Float128>
+     : fmt::formatter<double>
+{
+  template <class FormatContext>
+  auto format(Dune::Float128 v, FormatContext& ctx)
+  {
+    return fmt::formatter<double>::format(double(v), ctx);
+  }
+};
+
+#endif
+
+namespace Dune {
+namespace Impl {
+
+  template <class T, class F1, class F2>
+  void printErrorsImpl(std::vector<T> const& widths,
+                  std::vector<std::string> const& names,
+                  std::vector<std::vector<T>> const& errors,
+                  F1 print_line, F2 print_break)
+  {
+    using std::log;
+    // calculate experimental order of convergence
+    std::vector<std::vector<T>> eocs(errors.size(), std::vector<T>(1,T(0)));
+    for (std::size_t j = 0; j < errors.size(); ++j) {
+      for (std::size_t i = 1; i < widths.size(); ++i) {
+        eocs[j].push_back( log(errors[j][i]/errors[j][i-1]) / log(widths[i]/widths[i-1]) );
+      }
+    }
+
+    // print the headlines
+    std::vector<std::pair<std::string,std::string>> headlines;
+    for (std::size_t j = 0; j < names.size(); ++j)
+      headlines.push_back(std::make_pair(names[j], "(eoc) "));
+
+    print_line("lev","h", headlines);
+    print_break(headlines.size());
+
+    // print the data lines
+    for (std::size_t i = 0; i < widths.size(); ++i) {
+      std::vector<std::pair<std::string,std::string>> data;
+      for (std::size_t j = 0; j < errors.size(); ++j) {
+        data.push_back(std::make_pair(
+          fmt::format("{:8.4e}",errors[j][i]),
+          fmt::format("{:6.3f}",eocs[j][i]))
+        );
+      }
+      print_line(i, fmt::format("{:<8.6f}",widths[i]), data);
+    }
+  }
+
+} // end namespace Impl
+
+template <class T>
+void printErrorsClassic (std::ostream& out,
+                         std::vector<T> const& widths,
+                         std::vector<std::string> const& names,
+                         std::vector<std::vector<T>> const& errors)
+{
+  auto print_line = [&out](auto arg0, auto arg1, auto const& args) {
+    out << fmt::format("{:<3} | {:<8} ",arg0,arg1);
+    for (auto const& arg : args) {
+      out << fmt::format("| {:<13} | {:<5} ", arg.first, arg.second);
+    }
+    out << std::endl;
+  };
+
+  auto print_break = [&out](std::size_t n) {
+    out << fmt::format("{:-<3}---{:-<8}-","-","-");
+    for (std::size_t i = 0; i < n; ++i) {
+      out << fmt::format("-{:-<13}---{:-<7}-", "-", "-");
+    }
+    out << std::endl;
+  };
+
+  out << std::endl;
+  Impl::printErrorsImpl(widths, names, errors, print_line, print_break);
+}
+
+
+template <class T>
+void printErrorsLatex (std::ostream& out,
+                       std::vector<T> const& widths,
+                       std::vector<std::string> const& names,
+                       std::vector<std::vector<T>> const& errors)
+{
+  auto print_line = [&out](auto arg0, auto arg1, auto const& args) {
+    out << fmt::format("{:<3} & {:<8} ",arg0,arg1);
+    for (auto const& arg : args) {
+      out << fmt::format("& {:<13} & {:<5} ", arg.first, arg.second);
+    }
+    out << "\\\\" << std::endl;
+  };
+
+  auto print_break = [&out](std::size_t n) {
+    out << "\\hline" << std::endl;
+  };
+
+  out << std::endl;
+  out << "\\begin{tabular}{c|c";
+  for (std::size_t i = 0; i < names.size(); ++i)
+    out << "||c|c";
+  out << "}" << std::endl;
+  Impl::printErrorsImpl(widths, names, errors, print_line, print_break);
+  out << "\\end{tabular}" << std::endl;
+}
+
+
+template <class T>
+void printErrors (std::ostream& out,
+                  std::vector<T> const& widths,
+                  std::vector<std::string> const& names,
+                  std::vector<std::vector<T>> const& errors)
+{
+  auto print_line = [&out](auto arg0, auto arg1, auto const& args) {
+    out << fmt::format("{:<3} \u2502 {:<8} ",arg0,arg1);
+    for (auto const& arg : args) {
+      out << fmt::format("\u2502\u2502 {:<13} \u2502 {:<5} ", arg.first, arg.second);
+    }
+    out << std::endl;
+  };
+
+  auto print_break = [&out](std::size_t n) {
+    out << fmt::format("{:\u2500<3}\u2500\u253c\u2500{:\u2500<8}\u2500","\u2500","\u2500");
+    for (std::size_t i = 0; i < n; ++i) {
+      out << fmt::format("\u2524\u251c\u2500{:\u2500<13}\u2500\u253c\u2500{:\u2500<5}\u2500", "\u2500", "\u2500");
+    }
+    out << std::endl;
+  };
+
+  out << std::endl;
+  Impl::printErrorsImpl(widths, names, errors, print_line, print_break);
+}
+
+template <class T>
+void printErrorsCSV (std::ostream& out,
+                     std::vector<T> const& widths,
+                     std::vector<std::string> const& names,
+                     std::vector<std::vector<T>> const& errors)
+{
+  auto print_line = [&out](auto arg0, auto arg1, auto const& args) {
+    out << arg0 << ", " << arg1;
+    for (auto const& arg : args)
+      out << ", " << arg.first << ", " << arg.second;
+    out << std::endl;
+  };
+
+  auto print_break = [&out](std::size_t n) {};
+
+  Impl::printErrorsImpl(widths, names, errors, print_line, print_break);
+}
+
+} // end namespace Dune

--- a/src/runner.hh
+++ b/src/runner.hh
@@ -79,7 +79,7 @@ auto run(Dune::ParameterTree const& pt, const double& tau,  const Basis& feBasis
   for (int step = 0; t + tau < endTime + tol; ++step, t+= tau)
   {
     std::cout << step << "/" << nSteps;
-    std::cout << " surface = " << surface(gridView, Xh);
+    std::cout << " surface = " << Dune::BGN::surface(gridView, Xh);
     std::cout << std::endl;
     if ((step+1) % std::max(1,nSteps/100) == 0) {
       pvdWriter.writeTimestep(t, outputFileName, "_piecefiles");

--- a/src/runner.hh
+++ b/src/runner.hh
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <dune/assembler/backends/istlvectorbackend.hh>
+#include <dune/assembler/backends/istlmatrixbackend.hh>
+#include <dune/assembler/defaultglobalassembler.hh>
+#include <dune/assembler/parallel/gridcoloring.hh>
+#include <dune/assembler/parallel/coloredrangeexecutor.hh>
+#include <dune/common/parametertree.hh>
+#include <dune/curvedgeometry/localfunctiongeometry.hh>
+#include <dune/functions/functionspacebases/subspacebasis.hh>
+#include <dune/functions/functionspacebases/interpolate.hh>
+#include <dune/istl/bvector.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/umfpack.hh>
+#include <dune/vtk/pvdwriter.hh>
+#include <dune/vtk/vtkwriter.hh>
+
+#include "area.hh"
+#include "localfunctiongeometrydatacollector.hh"
+#include "umfpack2.hh"
+
+template <class Flow, class Basis, class InitialSurface>
+auto run(Dune::ParameterTree const& pt, const double& tau,  const Basis& feBasis, InitialSurface const& initialSurface, std::string outputFileName = "", std::size_t threadCount = 1)
+{
+  Dune::Timer timer;
+  using Matrix = Dune::BCRSMatrix<double>;
+  using Vector = Dune::BlockVector<double>;
+  Vector solution;
+
+  auto positionBasis = Dune::Functions::subspaceBasis(feBasis, Dune::Indices::_0);
+  auto curvatureBasis = Dune::Functions::subspaceBasis(feBasis, Dune::Indices::_1);
+
+  using GridView = typename Basis::GridView;
+  auto Xh = Dune::Functions::makeDiscreteGlobalBasisFunction<Dune::FieldVector<double,GridView::dimensionworld>>(positionBasis, solution);
+  auto Hh = Dune::Functions::makeDiscreteGlobalBasisFunction<double>(curvatureBasis, solution);
+  Dune::Functions::interpolate(positionBasis, solution, initialSurface);
+
+  auto gridView = feBasis.gridView();
+  const auto coloredRange = Dune::Assembler::Experimental::coloredElementRange(gridView);
+  auto executor = Dune::Assembler::Experimental::ColoredRangeExecutor(coloredRange, threadCount);
+  auto matrix = Matrix();
+  auto matrixBackend = Dune::Assembler::ISTLMatrixBackend(matrix);
+  auto rhs = Vector();
+  auto rhsBackend = Dune::Assembler::ISTLVectorBackend(rhs);
+  auto assembler = Dune::Assembler::Assembler(feBasis, feBasis, executor);
+
+  int quadOrder = pt.get<double>("solution.quad_order",10);
+  auto localAssembler = Flow{}(feBasis, std::cref(Xh), quadOrder, tau);
+
+  auto patternBuilder = matrixBackend.patternBuilder();
+  patternBuilder.resize(feBasis, feBasis);
+  assembler.assembleMatrixPattern(localAssembler, patternBuilder);
+  patternBuilder.setupMatrix();
+
+  // create linear solver
+  auto solver = Dune::BGN::UMFPack<Matrix>{};
+  solver.setVerbosity(pt.get<int>("solver.verbose"));
+
+  rhsBackend.resize(feBasis);
+
+  double startTime = pt.get<double>("adapt.start_time", 0.0);
+  double endTime = pt.get<double>("adapt.end_time", 0.03);
+  if (outputFileName.empty())
+    outputFileName = pt.get<std::string>("output.filename", "output.pvd");
+
+  using std::sqrt;
+  double tol = sqrt(std::numeric_limits<double>::epsilon());
+
+  Dune::Vtk::LocalFunctionGeometryDataCollector dataCollector{feBasis.gridView(), Xh, Dune::Vtk::CellType::QUADRATIC};
+  Dune::Vtk::UnstructuredGridWriter writer{dataCollector};
+  Dune::Vtk::PvdWriter pvdWriter{writer};
+
+  writer.write(outputFileName);
+  pvdWriter.writeTimestep(startTime, outputFileName, "_piecefiles");
+
+  double t = startTime;
+
+  int nSteps = int(std::ceil((endTime - startTime)/tau));
+  for (int step = 0; t + tau < endTime + tol; ++step, t+= tau)
+  {
+    std::cout << step << "/" << nSteps;
+    std::cout << " surface = " << surface(gridView, Xh);
+    std::cout << std::endl;
+    if ((step+1) % std::max(1,nSteps/100) == 0) {
+      pvdWriter.writeTimestep(t, outputFileName, "_piecefiles");
+    }
+
+    // assemble matrix and vector
+    matrixBackend.setZero();
+    assembler.assembleMatrixEntries(localAssembler, matrixBackend);
+    rhsBackend.setZero();
+    assembler.assembleVectorEntries(localAssembler, rhsBackend);
+
+    // solve the linear system
+    Dune::InverseOperatorResult statistics;
+    solver.setMatrix(matrix, {}, step>0);
+    solver.apply(solution, rhs, statistics);
+  }
+  pvdWriter.writeTimestep(endTime, outputFileName, "_piecefiles");
+
+  std::cout << "elapsed time: " << timer.elapsed() << std::endl;
+  return solution;
+}

--- a/src/surface_diffusion.hh
+++ b/src/surface_diffusion.hh
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <iostream>
+#include <vector>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+#include <dune/common/rangeutilities.hh>
+#include <dune/curvedgeometry/localfunctiongeometry.hh>
+#include <dune/geometry/quadraturerules.hh>
+
+
+namespace Dune::BGN {
+
+template <class LocalView, class GridFct>
+class SDLocalAssembler
+{
+  using GridView = typename LocalView::GridView;
+  using Element = typename LocalView::Element;
+  using LocalFct = std::decay_t<decltype(localFunction(std::declval<Dune::ResolveRef_t<GridFct> const&>()))>;
+
+  static const int dim = Element::dimension;
+  static const int dow = GridView::dimensionworld;
+
+public:
+  template <class Basis>
+  SDLocalAssembler (const Basis&, const GridFct& X, int quadOrder, double tau)
+    : X_(X)
+    // , X_e(localFunction(Dune::resolveRef(X_)))
+    , quadOrder_(quadOrder)
+    , tau_(tau)
+  {}
+
+  void bindLocalViews (const LocalView& testLocalView, const LocalView& trialLocalView)
+  {
+    testLocalView_ = &testLocalView;
+    trialLocalView_ = &trialLocalView;
+    X_e.emplace(localFunction(Dune::resolveRef(X_)));
+  }
+
+  void bindElement (const Element& element)
+  {
+    X_e->bind(element);
+  }
+
+  template <class LocalPattern>
+  void assembleElementMatrixPattern (const Element& e, LocalPattern& p) noexcept
+  {
+    using namespace Dune::Indices;
+    const auto& node = testLocalView_->tree();
+    const auto& localFE = node.child(_1).finiteElement();
+
+    for (auto i : Dune::range(localFE.size())) {
+      for (auto j : Dune::range(localFE.size())) {
+        auto row = node.child(_1).localIndex(i);
+        auto col = node.child(_1).localIndex(j);
+        p.add(row,col);
+
+        for (auto k : Dune::range(node.child(_0).degree())) {
+          auto row_k = node.child(_0).child(k).localIndex(i);
+          auto col_k = node.child(_0).child(k).localIndex(j);
+          p.add(row,col_k);
+          p.add(row_k,col);
+          p.add(row_k,col_k);
+        }
+      }
+    }
+  }
+
+  template <class LocalMatrix>
+  void assembleElementMatrix (const Element& e, LocalMatrix& localMatrix)
+  {
+    auto geometry = Dune::LocalFunctionGeometry{referenceElement(e), *X_e};
+
+    using namespace Dune::Indices;
+
+    const auto& node = testLocalView_->tree();
+    const auto& localFE = node.child(_1).finiteElement();
+    assert(node.child(_0).degree() == dow);
+
+    values_.resize(localFE.size());
+    jacobians_.resize(localFE.size());
+    refJacobians_.resize(localFE.size());
+
+    const auto& quad = Dune::QuadratureRules<double, dim>::rule(e.type(), quadOrder_);
+    for (const auto& [x,w] : quad)
+    {
+      const auto dx = geometry.integrationElement(x) * w;
+      const auto Jit = geometry.jacobianInverse(x);
+      const auto n = geometry.normal(x);
+
+      localFE.localBasis().evaluateFunction(x, values_);
+      localFE.localBasis().evaluateJacobian(x, refJacobians_);
+      for (auto i : Dune::range(localFE.size()))
+        jacobians_[i] = refJacobians_[i] * Jit;
+
+      for (auto i : Dune::range(localFE.size())) {
+        for (auto j : Dune::range(localFE.size())) {
+          auto row = node.child(_1).localIndex(i);
+          auto col = node.child(_1).localIndex(j);
+
+          // tau * (grad(v), grad(w))
+          const auto laplace = jacobians_[i][0].dot(jacobians_[j][0]);
+          localMatrix[row][col] -= tau_ * laplace * dx;
+
+          for (auto k : Dune::range(node.child(_0).degree())) {
+            auto row_k = node.child(_0).child(k).localIndex(i);
+            auto col_k = node.child(_0).child(k).localIndex(j);
+
+            // (v, normal*w)
+            const auto mass_normal = values_[i] * values_[j] * n[k];
+            localMatrix[row][col_k] += mass_normal * dx;
+            localMatrix[row_k][col] += mass_normal * dx;
+
+            // (grad(v), grad(w))
+            localMatrix[row_k][col_k] += laplace * dx;
+          }
+        }
+      }
+    }
+  }
+
+  void bindLocalView (const LocalView& testLocalView)
+  {
+    testLocalView_ = &testLocalView;
+    X_e.emplace(localFunction(Dune::resolveRef(X_)));
+  }
+
+  template <class LocalVector>
+  void assembleElementVector (const Element& e, LocalVector& localVector)
+  {
+    using namespace Dune::Indices;
+    auto geometry = Dune::LocalFunctionGeometry{referenceElement(e), *X_e};
+
+    const auto& node = testLocalView_->tree();
+    const auto& localFE = node.child(_1).finiteElement();
+    values_.resize(localFE.size());
+
+    const auto& quad = Dune::QuadratureRules<double, dim>::rule(e.type(), quadOrder_);
+    for (const auto& [x,w] : quad)
+    {
+      const auto dx = geometry.integrationElement(x) * w;
+      const auto n = geometry.normal(x);
+
+      localFE.localBasis().evaluateFunction(x, values_);
+
+      auto X_n = (*X_e)(x).dot(n);
+      for (auto i : Dune::range(localFE.size())) {
+        auto row = node.child(_1).localIndex(i);
+        localVector[row] += values_[i] * X_n * dx;
+      }
+    }
+  }
+
+private:
+  GridFct X_;
+  std::optional<LocalFct> X_e;
+  int quadOrder_;
+  double tau_;
+
+  const LocalView* testLocalView_ = nullptr;
+  const LocalView* trialLocalView_ = nullptr;
+  std::vector<Dune::FieldMatrix<double,1,dim>> refJacobians_;
+  std::vector<Dune::FieldMatrix<double,1,dow>> jacobians_;
+  std::vector<Dune::FieldVector<double,1>> values_;
+};
+
+template <class Basis, class GridFct>
+SDLocalAssembler(const Basis&, const GridFct& Xh, int, double)
+  -> SDLocalAssembler<typename Basis::LocalView, GridFct>;
+
+struct SurfaceDiffusion
+{
+  template <class Basis, class GridFct>
+  auto operator() (const Basis& basis, const GridFct& X, int quadOrder, double tau) const
+  {
+    return SDLocalAssembler{basis,X,quadOrder,tau};
+  }
+};
+
+} // end namespace Dune::BGN

--- a/src/umfpack2.hh
+++ b/src/umfpack2.hh
@@ -1,0 +1,599 @@
+// SPDX-FileCopyrightText: Copyright © DUNE Project contributors, see file LICENSE.md in module root
+// SPDX-License-Identifier: LicenseRef-GPL-2.0-only-with-DUNE-exception
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+#ifndef DUNE_ISTL_UMFPACK2_HH
+#define DUNE_ISTL_UMFPACK2_HH
+
+#if HAVE_SUITESPARSE_UMFPACK || defined DOXYGEN
+
+#include<complex>
+#include<type_traits>
+
+#include <dune/istl/umfpack.hh>
+
+
+
+namespace Dune::BGN {
+  /**
+   * @addtogroup ISTL
+   *
+   * @{
+   */
+  /**
+   * @file
+   * @author Dominic Kempf
+   * @brief Classes for using UMFPack with ISTL matrices.
+   */
+
+  // FORWARD DECLARATIONS
+  template<class M, class T, class TM, class TD, class TA>
+  class SeqOverlappingSchwarz;
+
+  template<class T, bool tag>
+  struct SeqOverlappingSchwarzAssemblerHelper;
+
+  /** @brief The %UMFPack direct sparse solver
+   *
+   * Details on UMFPack can be found on
+   * http://www.cise.ufl.edu/research/sparse/umfpack/
+   *
+   * %UMFPack will always use double precision.
+   * For complex matrices use a matrix type with std::complex<double>
+   * as the underlying number type.
+   *
+   * \tparam Matrix the matrix type defining the system
+   *
+   * \note This will only work if dune-istl has been configured to use UMFPack
+   */
+  template<typename M>
+  class UMFPack : public InverseOperator<Impl::UMFPackDomainType<M>,Impl::UMFPackRangeType<M>>
+  {
+    using T = typename M::field_type;
+
+    public:
+    using size_type = SuiteSparse_long;
+
+    /** @brief The matrix type. */
+    using Matrix = M;
+    using matrix_type = M;
+    /** @brief The corresponding (scalar) UMFPack matrix type.*/
+    using UMFPackMatrix = ISTL::Impl::BCCSMatrix<typename Matrix::field_type, size_type>;
+    /** @brief Type of an associated initializer class. */
+    using MatrixInitializer = ISTL::Impl::BCCSMatrixInitializer<M, size_type>;
+    /** @brief The type of the domain of the solver. */
+    using domain_type = Dune::Impl::UMFPackDomainType<M>;
+    /** @brief The type of the range of the solver. */
+    using range_type = Dune::Impl::UMFPackRangeType<M>;
+
+    //! Category of the solver (see SolverCategory::Category)
+    SolverCategory::Category category() const override
+    {
+      return SolverCategory::Category::sequential;
+    }
+
+    /** @brief Construct a solver object from a matrix
+     *
+     * This computes the matrix decomposition, and may take a long time
+     * (and use a lot of memory).
+     *
+     *  @param matrix the matrix to solve for
+     *  @param verbose [0..2] set the verbosity level, defaults to 0
+     */
+    UMFPack(const Matrix& matrix, int verbose=0) : matrixIsLoaded_(false)
+    {
+      //check whether T is a supported type
+      static_assert((std::is_same<T,double>::value) || (std::is_same<T,std::complex<double> >::value),
+                    "Unsupported Type in UMFPack (only double and std::complex<double> supported)");
+      Caller::defaults(UMF_Control);
+      setVerbosity(verbose);
+      setMatrix(matrix);
+    }
+
+    /** @brief Constructor for compatibility with SuperLU standard constructor
+     *
+     * This computes the matrix decomposition, and may take a long time
+     * (and use a lot of memory).
+     *
+     * @param matrix the matrix to solve for
+     * @param verbose [0..2] set the verbosity level, defaults to 0
+     */
+    UMFPack(const Matrix& matrix, int verbose, bool) : matrixIsLoaded_(false)
+    {
+      //check whether T is a supported type
+      static_assert((std::is_same<T,double>::value) || (std::is_same<T,std::complex<double> >::value),
+                    "Unsupported Type in UMFPack (only double and std::complex<double> supported)");
+      Caller::defaults(UMF_Control);
+      setVerbosity(verbose);
+      setMatrix(matrix);
+    }
+
+    /** @brief Construct a solver object from a matrix
+     *
+     * @param mat_    the matrix to solve for
+     * @param config  ParameterTree containing solver parameters.
+     *
+     * ParameterTree Key | Meaning
+     * ------------------|------------
+     * verbose           | The verbosity level. default=0
+    */
+    UMFPack(const Matrix& mat_, const ParameterTree& config)
+      : UMFPack(mat_, config.get<int>("verbose", 0))
+    {}
+
+    /** @brief default constructor
+     */
+    UMFPack() : matrixIsLoaded_(false), verbosity_(0)
+    {
+      //check whether T is a supported type
+      static_assert((std::is_same<T,double>::value) || (std::is_same<T,std::complex<double> >::value),
+                    "Unsupported Type in UMFPack (only double and std::complex<double> supported)");
+      Caller::defaults(UMF_Control);
+    }
+
+    /** @brief Try loading a decomposition from file and do a decomposition if unsuccessful
+     * @param mat_ the matrix to decompose when no decoposition file found
+     * @param file the decomposition file
+     * @param verbose the verbosity level
+     *
+     * Use saveDecomposition(char* file) for manually storing a decomposition. This constructor
+     * will decompose mat_ and store the result to file if no file wasn't found in the first place.
+     * Thus, if you always use this you will only compute the decomposition once (and when you manually
+     * deleted the decomposition file).
+     */
+    UMFPack(const Matrix& mat_, const char* file, int verbose=0)
+    {
+      //check whether T is a supported type
+      static_assert((std::is_same<T,double>::value) || (std::is_same<T,std::complex<double> >::value),
+                    "Unsupported Type in UMFPack (only double and std::complex<double> supported)");
+      Caller::defaults(UMF_Control);
+      setVerbosity(verbose);
+      int errcode = Caller::load_numeric(&UMF_Numeric, const_cast<char*>(file));
+      if ((errcode == UMFPACK_ERROR_out_of_memory) || (errcode == UMFPACK_ERROR_file_IO))
+      {
+        matrixIsLoaded_ = false;
+        setMatrix(mat_);
+        saveDecomposition(file);
+      }
+      else
+      {
+        matrixIsLoaded_ = true;
+        std::cout << "UMFPack decomposition successfully loaded from " << file << std::endl;
+      }
+    }
+
+    /** @brief try loading a decomposition from file
+     * @param file the decomposition file
+     * @param verbose the verbosity level
+     * @throws Dune::Exception When not being able to load the file. Does not need knowledge of the
+     * actual matrix!
+     */
+    UMFPack(const char* file, int verbose=0)
+    {
+      //check whether T is a supported type
+      static_assert((std::is_same<T,double>::value) || (std::is_same<T,std::complex<double> >::value),
+                    "Unsupported Type in UMFPack (only double and std::complex<double> supported)");
+      Caller::defaults(UMF_Control);
+      int errcode = Caller::load_numeric(&UMF_Numeric, const_cast<char*>(file));
+      if (errcode == UMFPACK_ERROR_out_of_memory)
+        DUNE_THROW(Dune::Exception, "ran out of memory while loading UMFPack decomposition");
+      if (errcode == UMFPACK_ERROR_file_IO)
+        DUNE_THROW(Dune::Exception, "IO error while loading UMFPack decomposition");
+      matrixIsLoaded_ = true;
+      std::cout << "UMFPack decomposition successfully loaded from " << file << std::endl;
+      setVerbosity(verbose);
+    }
+
+    virtual ~UMFPack()
+    {
+      if ((umfpackMatrix_.N() + umfpackMatrix_.M() > 0) || matrixIsLoaded_)
+        free();
+    }
+
+    /**
+     *  \copydoc InverseOperator::apply(X&, Y&, InverseOperatorResult&)
+     */
+    void apply(domain_type& x, range_type& b, InverseOperatorResult& res) override
+    {
+      if (umfpackMatrix_.N() != b.dim())
+        DUNE_THROW(Dune::ISTLError, "Size of right-hand-side vector b does not match the number of matrix rows!");
+      if (umfpackMatrix_.M() != x.dim())
+        DUNE_THROW(Dune::ISTLError, "Size of solution vector x does not match the number of matrix columns!");
+      if (b.size() == 0)
+        return;
+
+      // we have to convert x and b into flat structures
+      // however, this is linear in time
+      std::vector<T> xFlat(x.dim()), bFlat(b.dim());
+
+      flatVectorForEach(x, [&](auto&& entry, auto&& offset)
+      {
+        xFlat[ offset ] = entry;
+      });
+
+      flatVectorForEach(b, [&](auto&& entry, auto&& offset)
+      {
+        bFlat[ offset ] = entry;
+      });
+
+      double UMF_Apply_Info[UMFPACK_INFO];
+      Caller::solve(UMFPACK_A,
+                    umfpackMatrix_.getColStart(),
+                    umfpackMatrix_.getRowIndex(),
+                    umfpackMatrix_.getValues(),
+                    reinterpret_cast<double*>(&xFlat[0]),
+                    reinterpret_cast<double*>(&bFlat[0]),
+                    UMF_Numeric,
+                    UMF_Control,
+                    UMF_Apply_Info);
+
+      // copy back to blocked vector
+      flatVectorForEach(x, [&](auto&& entry, auto offset)
+      {
+        entry = xFlat[offset];
+      });
+
+      //this is a direct solver
+      res.iterations = 1;
+      res.converged = true;
+      res.elapsed = UMF_Apply_Info[UMFPACK_SOLVE_WALLTIME];
+
+      printOnApply(UMF_Apply_Info);
+    }
+
+    /**
+     *  \copydoc InverseOperator::apply(X&,Y&,double,InverseOperatorResult&)
+     */
+    void apply (domain_type& x, range_type& b, [[maybe_unused]] double reduction, InverseOperatorResult& res) override
+    {
+      apply(x,b,res);
+    }
+
+    /**
+     * @brief additional apply method with c-arrays in analogy to superlu
+     * @param x solution array
+     * @param b rhs array
+     *
+     * NOTE If the user hands over a pure pointer, we assume that they know what they are doing, hence no copy to flat structures
+     */
+    void apply(T* x, T* b)
+    {
+      double UMF_Apply_Info[UMFPACK_INFO];
+      Caller::solve(UMFPACK_A,
+                    umfpackMatrix_.getColStart(),
+                    umfpackMatrix_.getRowIndex(),
+                    umfpackMatrix_.getValues(),
+                    x,
+                    b,
+                    UMF_Numeric,
+                    UMF_Control,
+                    UMF_Apply_Info);
+      printOnApply(UMF_Apply_Info);
+    }
+
+    /** @brief Set UMFPack-specific options
+     *
+     * This method allows to set various options that control the UMFPack solver.
+     * More specifically, it allows to set values in the UMF_Control array.
+     * Please see the UMFPack documentation for a list of possible options and values.
+     *
+     * \param option Entry in the UMF_Control array, e.g., UMFPACK_IRSTEP
+     * \param value Corresponding value
+     *
+     * \throws RangeError If nonexisting option was requested
+     */
+    void setOption(unsigned int option, double value)
+    {
+      if (option >= UMFPACK_CONTROL)
+        DUNE_THROW(RangeError, "Requested non-existing UMFPack option");
+
+      UMF_Control[option] = value;
+    }
+
+    /** @brief saves a decomposition to a file
+     * @param file the filename to save to
+     */
+    void saveDecomposition(const char* file)
+    {
+      int errcode = Caller::save_numeric(UMF_Numeric, const_cast<char*>(file));
+      if (errcode != UMFPACK_OK)
+        DUNE_THROW(Dune::Exception,"IO ERROR while trying to save UMFPack decomposition");
+    }
+
+    /** @brief Initialize data from given matrix.
+     *
+     * \tparam BitVector a compatible bitvector to the domain_type/range_type.
+     *         Defaults to NoBitVector for backwards compatibility
+     *
+     *  A positive bit indices that the corresponding matrix row/column is excluded from the
+     *  UMFPACK decomposition.
+     *  WARNING This is an opposite behavior of the previous implementation in `setSubMatrix`.
+     */
+    template<class BitVector = Impl::NoBitVector>
+    void setMatrix(const Matrix& matrix, const BitVector& bitVector = {}, bool keepSymbolic = false)
+    {
+      if ((umfpackMatrix_.N() + umfpackMatrix_.M() > 0) || matrixIsLoaded_)
+        free(keepSymbolic);
+      if (matrix.N() == 0 or matrix.M() == 0)
+        return;
+
+      if (umfpackMatrix_.N() + umfpackMatrix_.M() + umfpackMatrix_.nonzeroes() != 0)
+        umfpackMatrix_.free();
+
+      constexpr bool useBitVector = not std::is_same_v<BitVector,Impl::NoBitVector>;
+
+      // use a dynamic flat vector for the bitset
+      std::vector<bool> flatBitVector;
+      // and a mapping from the compressed indices
+      std::vector<size_type> subIndices;
+
+      [[maybe_unused]] int numberOfIgnoredDofs = 0;
+      int nonZeros = 0;
+
+      if constexpr ( useBitVector )
+      {
+        auto flatSize = flatVectorForEach(bitVector, [](auto&&, auto&&){});
+        flatBitVector.resize(flatSize);
+
+        flatVectorForEach(bitVector, [&](auto&& entry, auto&& offset)
+        {
+          flatBitVector[ offset ] = entry;
+          if ( entry )
+          {
+            numberOfIgnoredDofs++;
+          }
+        });
+      }
+
+      // compute the flat dimension and the number of nonzeros of the matrix
+      auto [flatRows,flatCols] = flatMatrixForEach( matrix, [&](auto&& /*entry*/, auto&& row, auto&& col){
+        // do not count ignored entries
+        if constexpr ( useBitVector )
+          if ( flatBitVector[row] or flatBitVector[col] )
+            return;
+
+        nonZeros++;
+      });
+
+      if constexpr ( useBitVector )
+      {
+        // use the original flatRows!
+        subIndices.resize(flatRows,std::numeric_limits<std::size_t>::max());
+
+        size_type subIndexCounter = 0;
+        for ( size_type i=0; i<size_type(flatRows); i++ )
+          if ( not  flatBitVector[ i ] )
+            subIndices[ i ] = subIndexCounter++;
+
+        // update the original matrix size
+        flatRows -= numberOfIgnoredDofs;
+        flatCols -= numberOfIgnoredDofs;
+      }
+
+
+      umfpackMatrix_.setSize(flatRows,flatCols);
+      umfpackMatrix_.Nnz_ = nonZeros;
+
+      // prepare the arrays
+      umfpackMatrix_.colstart = new size_type[flatCols+1];
+      umfpackMatrix_.rowindex = new size_type[nonZeros];
+      umfpackMatrix_.values   = new T[nonZeros];
+
+      for ( size_type i=0; i<size_type(flatCols+1); i++ )
+      {
+        umfpackMatrix_.colstart[i] = 0;
+      }
+
+      // at first, we need to compute the column start indices
+      // therefore, we count all entries in each column and in the end we accumulate everything
+      flatMatrixForEach(matrix, [&](auto&& /*entry*/, auto&& flatRowIndex, auto&& flatColIndex)
+      {
+        // do nothing if entry is excluded
+        if constexpr ( useBitVector )
+          if ( flatBitVector[flatRowIndex] or flatBitVector[flatColIndex] )
+            return;
+
+        // pick compressed or uncompressed index
+        // compiler will hopefully do some constexpr optimization here
+        auto colIdx = useBitVector ? subIndices[flatColIndex] : flatColIndex;
+
+        umfpackMatrix_.colstart[colIdx+1]++;
+      });
+
+      // now accumulate
+      for ( size_type i=0; i<(size_type)flatCols; i++ )
+      {
+        umfpackMatrix_.colstart[i+1] += umfpackMatrix_.colstart[i];
+      }
+
+      // we need a compressed position counter in each column
+      std::vector<size_type> colPosition(flatCols,0);
+
+      // now we can set the entries: the procedure below works with both row- or column major index ordering
+      flatMatrixForEach(matrix, [&](auto&& entry, auto&& flatRowIndex, auto&& flatColIndex)
+      {
+        // do nothing if entry is excluded
+        if constexpr ( useBitVector )
+          if ( flatBitVector[flatRowIndex] or flatBitVector[flatColIndex] )
+            return;
+
+        // pick compressed or uncompressed index
+        // compiler will hopefully do some constexpr optimization here
+        auto rowIdx = useBitVector ? subIndices[flatRowIndex] : flatRowIndex;
+        auto colIdx = useBitVector ? subIndices[flatColIndex] : flatColIndex;
+
+        // the start index of each column is already fixed
+        auto colStart = umfpackMatrix_.colstart[colIdx];
+        // get the current number of picked elements in this column
+        auto colPos   = colPosition[colIdx];
+        // assign the corresponding row index and the value of this element
+        umfpackMatrix_.rowindex[ colStart + colPos ] = rowIdx;
+        umfpackMatrix_.values[ colStart + colPos ] = entry;
+        // increase the number of picked elements in this column
+        colPosition[colIdx]++;
+      });
+
+      decompose(keepSymbolic);
+    }
+
+    // Keep legacy version using a set of scalar indices
+    // The new version using a bitVector type for marking the active matrix indices is
+    // directly given in `setMatrix` with an additional BitVector argument.
+    // The new version is more flexible and allows, e.g., marking single components of a matrix block.
+    template<typename S>
+    void setSubMatrix(const Matrix& _mat, const S& rowIndexSet, bool keepSymbolic = false)
+    {
+      if ((umfpackMatrix_.N() + umfpackMatrix_.M() > 0) || matrixIsLoaded_)
+        free(keepSymbolic);
+
+      if (umfpackMatrix_.N() + umfpackMatrix_.M() + umfpackMatrix_.nonzeroes() != 0)
+        umfpackMatrix_.free();
+
+      umfpackMatrix_.setSize(rowIndexSet.size()*MatrixDimension<Matrix>::rowdim(_mat) / _mat.N(),
+                             rowIndexSet.size()*MatrixDimension<Matrix>::coldim(_mat) / _mat.M());
+      ISTL::Impl::BCCSMatrixInitializer<Matrix, SuiteSparse_long> initializer(umfpackMatrix_);
+
+      copyToBCCSMatrix(initializer, ISTL::Impl::MatrixRowSubset<Matrix,std::set<std::size_t> >(_mat,rowIndexSet));
+
+      decompose(keepSymbolic);
+    }
+
+    /** @brief sets the verbosity level for the UMFPack solver
+     * @param v verbosity level
+     * The following levels are implemented:
+     * 0 - only error messages
+     * 1 - a bit of statistics on decomposition and solution
+     * 2 - lots of statistics on decomposition and solution
+     */
+    void setVerbosity(int v)
+    {
+      verbosity_ = v;
+      // set the verbosity level in UMFPack
+      if (verbosity_ == 0)
+        UMF_Control[UMFPACK_PRL] = 1;
+      if (verbosity_ == 1)
+        UMF_Control[UMFPACK_PRL] = 2;
+      if (verbosity_ == 2)
+        UMF_Control[UMFPACK_PRL] = 4;
+    }
+
+    /**
+     * @brief Return the matrix factorization.
+     * @warning It is up to the user to keep consistency.
+     */
+    void* getFactorization()
+    {
+      return UMF_Numeric;
+    }
+
+    /**
+     * @brief Return the column compress matrix from UMFPack.
+     * @warning It is up to the user to keep consistency.
+     */
+    UMFPackMatrix& getInternalMatrix()
+    {
+      return umfpackMatrix_;
+    }
+
+    /**
+     * @brief free allocated space.
+     * @warning later calling apply will result in an error.
+     */
+    void free(bool keepSymbolic = false)
+    {
+      if (!matrixIsLoaded_)
+      {
+        if (!keepSymbolic && UMF_Symbolic)
+          Caller::free_symbolic(&UMF_Symbolic);
+        umfpackMatrix_.free();
+      }
+      if (UMF_Numeric)
+        Caller::free_numeric(&UMF_Numeric);
+
+      matrixIsLoaded_ = false;
+    }
+
+    const char* name() { return "UMFPACK"; }
+
+    private:
+    typedef typename Dune::UMFPackMethodChooser<T> Caller;
+
+    template<class Mat,class X, class TM, class TD, class T1>
+    friend class SeqOverlappingSchwarz;
+    friend struct SeqOverlappingSchwarzAssemblerHelper<UMFPack<Matrix>,true>;
+
+    /** @brief computes the LU Decomposition */
+    void decompose(bool keepSymbolic)
+    {
+      double UMF_Decomposition_Info[UMFPACK_INFO];
+      if (!keepSymbolic || !UMF_Symbolic) {
+        Caller::symbolic(static_cast<SuiteSparse_long>(umfpackMatrix_.N()),
+                        static_cast<SuiteSparse_long>(umfpackMatrix_.N()),
+                        umfpackMatrix_.getColStart(),
+                        umfpackMatrix_.getRowIndex(),
+                        reinterpret_cast<double*>(umfpackMatrix_.getValues()),
+                        &UMF_Symbolic,
+                        UMF_Control,
+                        UMF_Decomposition_Info);
+      }
+      Caller::numeric(umfpackMatrix_.getColStart(),
+                      umfpackMatrix_.getRowIndex(),
+                      reinterpret_cast<double*>(umfpackMatrix_.getValues()),
+                      UMF_Symbolic,
+                      &UMF_Numeric,
+                      UMF_Control,
+                      UMF_Decomposition_Info);
+      Caller::report_status(UMF_Control,UMF_Decomposition_Info[UMFPACK_STATUS]);
+      if (verbosity_ == 1)
+      {
+        std::cout << "[UMFPack Decomposition]" << std::endl;
+        std::cout << "Wallclock Time taken: " << UMF_Decomposition_Info[UMFPACK_NUMERIC_WALLTIME] << " (CPU Time: " << UMF_Decomposition_Info[UMFPACK_NUMERIC_TIME] << ")" << std::endl;
+        std::cout << "Flops taken: " << UMF_Decomposition_Info[UMFPACK_FLOPS] << std::endl;
+        std::cout << "Peak Memory Usage: " << UMF_Decomposition_Info[UMFPACK_PEAK_MEMORY]*UMF_Decomposition_Info[UMFPACK_SIZE_OF_UNIT] << " bytes" << std::endl;
+        std::cout << "Condition number estimate: " << 1./UMF_Decomposition_Info[UMFPACK_RCOND] << std::endl;
+        std::cout << "Numbers of non-zeroes in decomposition: L: " << UMF_Decomposition_Info[UMFPACK_LNZ] << " U: " << UMF_Decomposition_Info[UMFPACK_UNZ] << std::endl;
+      }
+      if (verbosity_ == 2)
+      {
+        Caller::report_info(UMF_Control,UMF_Decomposition_Info);
+      }
+    }
+
+    void printOnApply(double* UMF_Info)
+    {
+      Caller::report_status(UMF_Control,UMF_Info[UMFPACK_STATUS]);
+      if (verbosity_ > 0)
+      {
+        std::cout << "[UMFPack Solve]" << std::endl;
+        std::cout << "Wallclock Time: " << UMF_Info[UMFPACK_SOLVE_WALLTIME] << " (CPU Time: " << UMF_Info[UMFPACK_SOLVE_TIME] << ")" << std::endl;
+        std::cout << "Flops Taken: " << UMF_Info[UMFPACK_SOLVE_FLOPS] << std::endl;
+        std::cout << "Iterative Refinement steps taken: " << UMF_Info[UMFPACK_IR_TAKEN] << std::endl;
+        std::cout << "Error Estimate: " << UMF_Info[UMFPACK_OMEGA1] << " resp. " << UMF_Info[UMFPACK_OMEGA2] << std::endl;
+      }
+    }
+
+    UMFPackMatrix umfpackMatrix_;
+    bool matrixIsLoaded_;
+    int verbosity_;
+    void *UMF_Symbolic = nullptr;
+    void *UMF_Numeric = nullptr;
+    double UMF_Control[UMFPACK_CONTROL];
+  };
+
+} // end namespace Dune::BGN
+
+template<typename T, typename A, int n, int m>
+struct Dune::IsDirectSolver<Dune::BGN::UMFPack<Dune::BCRSMatrix<Dune::FieldMatrix<T,n,m>,A> > >
+{
+  enum { value=true};
+};
+
+template<typename T, typename A>
+struct Dune::StoresColumnCompressed<Dune::BGN::UMFPack<Dune::BCRSMatrix<T,A> > >
+{
+  enum { value = true };
+};
+
+#endif // HAVE_SUITESPARSE_UMFPACK
+
+#endif //DUNE_ISTL_UMFPACK2_HH


### PR DESCRIPTION
This MR adds several things. 
- A new example with the boundary of a box domain as surface grid, 
- A local assembler based on [dune-assembler](https://gitlab.dune-project.org/staging/dune-assembler) that allows to use a thread-based assembling strategy
- An improved direct solver UMFPACK that allows to reuse the symbolic factorization in subsequent solves
- A reimplementation of mean-curvature flow and surface-diffusion
- A data-collector for Dune::Vtk allowing to directly visualize parametrized geometries without `Dune::CurvedGrid`
- Utilities to compute the surface area and the element size for stability evaluations and convergence orders
- A utility to print the convergence table in a nicely formatted style (using fmtlib)

It requires the branch `feature/alglib-solver` in dune-meshdist